### PR TITLE
docs(changelog): adicionar CHANGELOG.md e preparar release v1.2.0 (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+\# Changelog
+
+Todos os registros de alterações deste projeto seguem o padrão
+
+\[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+e \[Semantic Versioning](https://semver.org/).
+
+
+
+\## \[1.2.0] - 2025-11-XX
+
+\### Adicionado
+
+\- Arquivo CHANGELOG.md.
+
+\- Release v1.2.0 documentada.
+
+\- Badge de status dos testes no README.
+
+
+
+\### Alterado
+
+\- Documentação atualizada (README com logo Bruttus).
+
+
+
+\### Relacionado
+
+\- Issue #7
+
+
+
+---
+
+
+
+\## \[1.1.0] - 2025-11-XX
+
+\### Alterado
+
+\- Refatoração com MENU centralizado.
+
+\- Criação de funções para separar responsabilidades (SRP/DRY).
+
+\- Adição de type hints e docstrings.
+
+
+
+\### Relacionado
+
+\- PR #3
+
+
+
+---
+
+
+
+\## \[1.0.1] - 2025-10-XX
+
+\### Corrigido
+
+\- Bugs óbvios do código original (listas trocadas, multiplicações inválidas, etc.).
+
+
+
+\### Relacionado
+
+\- PR #2
+
+
+
+---
+
+
+
+\## \[1.0.0] - 2025-10-XX
+
+\### Criado
+
+\- Versão inicial do sistema de pedidos da hamburgueria.
+


### PR DESCRIPTION
O que foi feito
Criado arquivo CHANGELOG.md seguindo o padrão Keep a Changelog.
Documentadas as versões 1.0.0, 1.0.1, 1.1.0 e 1.2.0.
(Opcional) README atualizado com link para o changelog.

Como testar
Verificar o arquivo CHANGELOG.md na raiz do projeto.
Conferir se as informações históricas batem com os PRs anteriores.

Motivação
Registrar a evolução do projeto de forma profissional.
Preparar o repositório para a Release v1.2.0.

Closes #7